### PR TITLE
Fixed a small error in the permissions list of the CrazyAuctions plugin

### DIFF
--- a/docs/plugins/crazyauctions/commands/permissions.md
+++ b/docs/plugins/crazyauctions/commands/permissions.md
@@ -32,7 +32,7 @@ If you wish for a player to add items to the selling and or bidding section of t
 Players need BOTH PERMISSIONS to put their items in the selling section.
 * `crazyauctions.sell`
 * `crazyauctions.sell.#`
-#### *Replace the # with the max amount of items they can have in the bidding section.
+#### *Replace the # with the max amount of items they can have in the selling section.
 ### Bidding:
 Players need BOTH PERMISSIONS to put their items into the bidding section.
 * `crazyauctions.bid`


### PR DESCRIPTION
There was a small error in the documentation for the CrazyAuctions plugin. In the permission list is sais bidding section in a place where it is supossed to say selling section. It's a very minor mistake but it should be fixed.